### PR TITLE
parameter value base64 encoding

### DIFF
--- a/lib/thunder/cloud_implementation/aws.rb
+++ b/lib/thunder/cloud_implementation/aws.rb
@@ -1,4 +1,6 @@
-#######################
+require 'base64'
+
+######################
 # AMAZON WEB SERVICES #
 #######################
 #
@@ -199,10 +201,20 @@ module Thunder
           hash[item[0]] = OLD_TRIGGER; hash }
       end
 
+      def load_yaml_parameters(file)
+        o = YAML.load(File.read(file))
+        o.keys.each do |k|
+          if o[k].respond_to? :has_key?
+            o[k] = Base64.encode64( o[k]["base64"]) if o[k].has_key? "base64"
+          end
+        end
+        return o
+      end
+
       def parameters_parsers()
         return {
           ".json" => lambda {|r| JSON.parse(File.read(r)) },
-          ".yaml" => lambda {|r| YAML.load(File.read(r)) },
+          ".yaml" => lambda {|r| load_yaml_parameters(r) },
           ".OLD" => lambda {|x| remote_param_old(x) },
           "" =>  lambda {|x| remote_param_default(x) }
         }

--- a/lib/thunder/cloud_implementation/openstack.rb
+++ b/lib/thunder/cloud_implementation/openstack.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 #######################
 # OPENSTACK           #
 #######################
@@ -160,15 +162,25 @@ module Thunder
           hash[item[0]] = OLD_TRIGGER; hash }
       end
 
+
+      def load_yaml_parameters(file)
+        o = YAML.load(File.read(file))
+        o.keys.each do |k|
+          if o[k].respond_to? :has_key?
+            o[k] = Base64.encode64( o[k]["base64"]) if o[k].has_key? "base64"
+          end
+        end
+        return o
+      end
+
       def parameters_parsers()
         return {
           ".json" => lambda {|r| JSON.parse(File.read(r)) },
-          ".yaml" => lambda {|r| YAML.load(File.read(r)) },
+          ".yaml" => lambda {|r| load_yaml_parameters(r) },
           ".OLD" => lambda {|x| remote_param_old(x) },
-          "" =>  lambda {|x| remote_param_default(x)}
+          "" =>  lambda {|x| remote_param_default(x) }
         }
       end
-
 
       #this method is identical to that in the other class--migrate up to
       #CloudFormation class?

--- a/lib/thunder/version.rb
+++ b/lib/thunder/version.rb
@@ -1,3 +1,3 @@
 module Thunder
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end


### PR DESCRIPTION
Add the ability to specify that the value of a parameter should be base64
encoded before it gets sent to the cloud orchestration environment.

If you have a yaml parameters file, you can do the following

``` yaml
myParameter:
  base64: |
    This will be encoded.
```

When thunder encounders a value that is a hash contining the key "base64", it will
substitute the base64 encodeing of the value. An equivalent parameters file would be

```
myParameter: VGhpcyB3aWxsIGJlIGVuY29kZWQuCg==
```
