### PR TITLE
Info Command

### DIFF
--- a/lib/thunder/app.rb
+++ b/lib/thunder/app.rb
@@ -35,6 +35,28 @@ module Thunder
       say "Config updated with native #{flavor}"
     end
 
+    desc 'info', 'Display info about currently configured cloud connection. Optional [STACK]'
+    def info(stack_name = nil)
+      implementation_selector == :openstack ? os_info : aws_info
+      if stack_name
+        exist_info = con.present_stacks.find{ |s| s[:Name] == stack_name } ? 'exists' : 'does not exist'
+        say "Stack: '#{stack_name}' #{exist_info}"
+      end
+    end
+
+    no_commands do
+      def aws_info
+        say "Account Alias: #{con.iam.account_alias}"
+        say "Account Id: #{con.account_id}"
+        region = configuration[:region]
+        say "Region: #{region} (#{con.region_map[region]})"
+      end
+
+      def os_info
+        #TODO
+      end
+    end
+
     desc 'stack [COMMAND]', 'Stack actions'
     subcommand 'stack', Subcommand::Stack
 

--- a/lib/thunder/cloud_implementation/aws.rb
+++ b/lib/thunder/cloud_implementation/aws.rb
@@ -45,6 +45,10 @@ module Thunder
         @s3 ||= ::AWS::S3.new(region: 'us-east-1')
       end
 
+      def iam
+        @iam ||= ::AWS::IAM.new
+      end
+
       def config_aws(thunder_config)
         ::AWS.config(region: thunder_config[:region],
                      access_key_id: thunder_config[:aws_access_key_id],
@@ -231,6 +235,20 @@ module Thunder
         return filtered_parameters
       end
 
+      def region_map
+        {
+          'us-east-1'      => 'N. Virginia',
+          'us-west-1'      => 'N. California',
+          'us-west-2'      => 'Oregon',
+          'eu-west-1'      => 'Ireland',
+          'eu-central-1'   => 'Frankfurt',
+          'ap-southeast-1' => 'Singapore',
+          'ap-southeast-2' => 'Sydney',
+          'ap-northeast-1' => 'Tokyo',
+          'sa-east-1'      => 'Sao Paulo',
+        }
+      end
+
       def display_events(events, options)
         table = []
         events.each do |event|
@@ -292,6 +310,19 @@ module Thunder
 
       def send_key(name, public_key)
         ec2.key_pairs.import(name, public_key)
+      end
+
+      def users
+        iam.users
+      end
+
+      def arn(name = nil)
+        name ? users[name].arn : users.first.arn
+      end
+
+      def account_id(name = nil)
+        match = arn(name).match(/arn:(?<partition>[^:]*):(?<service>[^:]*):(?<region>[^:]*):(?<account>\d+):(?<resourcetype>[^:]*)\/(?<resource>[^:]*)/)
+        match[:account]
       end
 
     end

--- a/lib/thunder/version.rb
+++ b/lib/thunder/version.rb
@@ -1,3 +1,3 @@
 module Thunder
-  VERSION = '1.3.3'
+  VERSION = '1.3.4'
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -11,6 +11,7 @@ describe Thunder::App do
           thunder config .*
           thunder config_import .*
           thunder help .*
+          thunder info .*
           thunder keypair .*
           thunder poll .*
           thunder remote_file .*


### PR DESCRIPTION
Just a quick little add-on to `thunder` to assist with managing multiple AWS accounts and SRPs.

The stack name is optional here.
```
bundle exec thunder info travis -S demo
Account Alias: engineering-demo-infochimps
Account Id: 875735948112
Region: us-west-1 (N. California)
Stack: 'travis' exists
```

@howech @erikmack @geometrid @gardella @joshbronson @aseever @davidsnyder @crawlik 