### PR TITLE
Support openstack identity v3 API (domains)

### DIFF
--- a/lib/thunder/cloud_implementation/openstack.rb
+++ b/lib/thunder/cloud_implementation/openstack.rb
@@ -271,11 +271,12 @@ module Thunder
         creds[:openstack_user_domain] = os_vars[:openstack_user_domain]
         creds[:connection_options] = os_vars[:connection_options] || {}
 
-        creds[:connection_options] ||= {} #JSON.parse(creds[:connection_options]) if creds[:connection_options]
         return creds
       end
 
       def orch
+        auth_uri_obj = URI.parse(@config[:openstack_auth_url])
+        @auth ||= Fog::OpenStack::authenticate({ provider: 'openstack', openstack_auth_uri: auth_uri_obj, openstack_service_type: 'orchestration', openstack_service_name: 'heat'}.merge(@config), @config[:connection_options])
         @orch ||= Fog::Orchestration.new({ provider: 'openstack'}.merge(@config))
       end
 
@@ -306,21 +307,26 @@ module Thunder
       #keys provided in stack_hole
       PATH_DIVIDER = "/"
       def os_retrieve(api_stub, path)
-        tenant = @config[:openstack_tenant]
-        user = @config[:openstack_username]
-        pass = @config[:openstack_api_key]
-        auth_url = @config[:openstack_auth_url]
 
-        #auth
-        auth = os_auth(auth_url, tenant, user, pass)
-        token = auth["access"]["token"]["id"]
-        svc_catalog = auth["access"]["serviceCatalog"]
-        svc_catalog = Hash[svc_catalog.map { |x| [x["name"], x] }]
+        token = @auth[:token]
+        api_url = @auth[:server_management_url]
 
-        #retrieve
-        api_url = svc_catalog["heat"]["endpoints"][0]["publicURL"]
         api_call = api_url+api_stub
-        response = os_api("GET", api_call, token, {})
+
+        verify_ssl = OpenSSL::SSL::VERIFY_PEER
+        if @config[:connection_options] and not @config[:connection_options][:ssl_verify_peer].nil? and @config[:connection_options][:ssl_verify_peer] == false
+          verify_ssl = OpenSSL::SSL::VERIFY_NONE
+        end
+
+        client = RestClient::Request.new(
+                                         :method => 'GET',
+                                         :url => api_call,
+                                         :headers => {"User-Agent"   => "thunder",
+                                                      "X-Auth-Token" => token},
+                                         :verify_ssl => verify_ssl
+                                         )
+
+        response = client.execute
         response = JSON.parse(response)
 
         # get the result from the desired path
@@ -332,42 +338,6 @@ module Thunder
         return cursor
       end
 
-      # Lowest-level interfaces #
-      #get authentication token and relevant endpoints
-      def os_auth(url,tenant,user,pass)
-
-        authdata = {"auth" =>
-          {"tenantName" => tenant,
-            "passwordCredentials" =>
-            {"username" => user,
-              "password" => pass }}}
-        client = RestClient::Request.new(
-                                         :method => "POST",
-                                         :url => url,
-                                         :headers => {"Content-Type" => "application/json",
-                                           "Accept"       => "application/json"},
-                                         :payload => authdata.to_json,
-                                         )
-
-        response = client.execute
-        return JSON.parse(response)
-      end
-
-
-      def os_api(method, url, token, data)
-
-        client = RestClient::Request.new(
-                                         :method => method,
-                                         :url => url,
-                                         :headers => {"User-Agent"   => "thunder",
-                                           "X-Auth-Token" => token},
-                                         :payload => data.to_json ,
-                                         )
-
-        response = client.execute
-        return response
-
-      end
     end
   end
 end

--- a/lib/thunder/cloud_implementation/openstack.rb
+++ b/lib/thunder/cloud_implementation/openstack.rb
@@ -267,6 +267,8 @@ module Thunder
         creds[:openstack_username] = os_vars[:openstack_username]
         creds[:openstack_tenant] = os_vars[:openstack_tenant]
         creds[:openstack_api_key] = os_vars[:openstack_api_key]
+        creds[:openstack_project_domain] = os_vars[:openstack_project_domain]
+        creds[:openstack_user_domain] = os_vars[:openstack_user_domain]
         creds[:connection_options] = os_vars[:connection_options] || {}
 
         creds[:connection_options] ||= {} #JSON.parse(creds[:connection_options]) if creds[:connection_options]

--- a/lib/thunder/configuration.rb
+++ b/lib/thunder/configuration.rb
@@ -17,7 +17,7 @@ module Thunder
     end
 
     def os_options
-      %w(openstack_auth_url openstack_username openstack_tenant openstack_api_key connection_options).map(&:to_sym)
+      %w(openstack_auth_url openstack_username openstack_tenant openstack_api_key openstack_project_domain openstack_user_domain connection_options).map(&:to_sym)
     end
 
     def all_options

--- a/thunder.gemspec
+++ b/thunder.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('activesupport', '~> 4.1.5')
   gem.add_dependency('aws-sdk',       '~> 1.50.0')
   gem.add_dependency('cfndsl',        '>= 0.3.2')
-  gem.add_dependency('fog',           '~> 1.23.0')
+  gem.add_dependency('fog',           '~> 1.37.0')
   gem.add_dependency('formatador',    '~> 0.2.5')
   gem.add_dependency('parseconfig',   '~> 1.0.4')
   gem.add_dependency('rest-client',   '~> 1.7.2')


### PR DESCRIPTION
First, pin to the latest fog release which groks domains.  Add the two required variables (openstack_project_domain and openstack_user_domain, which get identical values).  Finally, factor some custom REST calls to keystone to use fog instead.

This change unlocks our platform using the EMC Neutrino product, as well as any other client environments that use domains.